### PR TITLE
[feature implemented]: Spawning and utilizing multiple instances on the same node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 htmlcov/
 .coverage
 
+local_runs/
 notes/
 .cursor
 

--- a/configs/aegis_configs/single_file.yaml
+++ b/configs/aegis_configs/single_file.yaml
@@ -1,20 +1,21 @@
 port_start: 8000
 hf_home: /tmp/hf_home
-hf_token: <YOUR_HF_TOKEN>
+hf_token: <your token>
 walltime: "01:00:00"
 account: ModCon
-queue: debug
+queue: debug-scaling
 filesystems: flare:home
-endpoints_file: /home/ogokdemir/ExaForge/aegis_endpoints.txt
+endpoints_file: /home/ogokdemir/ExaForge/local_runs/aegis_endpoints.txt
 conda_env: /home/ogokdemir/Aegis/assets/condapacks/vllm_oss_conda_pack_01082026.tar.gz
 aegis_env: /home/ogokdemir/.conda/envs/exaforge-env/
 
 
 models:
-  - model: meta-llama/Llama-3.1-8B-Instruct
-    instances: 2
+  - model: openai/gpt-oss-120b
+    #PBS will request 64 / (12 / tensor_parallel_size) nodes on Aurora. Ensure divisibility.
+    instances: 96
     tensor_parallel_size: 4
-    model_source: /flare/datasets/model-weights/hub/models--meta-llama--Llama-3.1-8B-Instruct
+    model_source: /flare/datasets/model-weights/hub/models--openai--gpt-oss-120b
     download_weights: false
     extra_vllm_args:
       - --max-model-len

--- a/configs/task_configs/data_card_extract_test.yaml
+++ b/configs/task_configs/data_card_extract_test.yaml
@@ -11,7 +11,7 @@ aegis:
     config_path: /home/ogokdemir/ExaForge/configs/aegis_configs/single_file.yaml
     auto_launch: true
     wait_for_endpoints: true
-    endpoints_file: /home/ogokdemir/ExaForge/aegis_endpoints.txt
+    endpoints_file: /home/ogokdemir/ExaForge/local_runs/aegis_endpoints.txt
 
 task:
     name: card_extraction
@@ -24,7 +24,7 @@ task:
 
 reader:
     name: text_directory
-    input_dir: /lus/flare/projects/FRAME-IDP/ogokdemir/data/exaforge_data/test_papers
+    input_dir: /lus/flare/projects/LUCID/ogokdemir/data/SC/SC-Parsed
     glob_patterns:
         - "*.mmd"
 
@@ -36,11 +36,11 @@ writer:
 
 client:
     # Must match vLLM's served model id (same as `model:` in the Aegis config), not the on-disk hub folder name.
-    model: meta-llama/Llama-3.1-8B-Instruct
+    model: openai/gpt-oss-120b
     # Global in-flight request cap across ALL endpoints combined.
     # Rule of thumb for production: num_endpoints × desired_queue_depth
     # e.g. 12 endpoints × 16 = 192. For this test run 64 is fine.
-    max_concurrent_requests: 16
+    max_concurrent_requests: 1536 # 1536 = 96 (instances) * 16 (requests per instance)
     timeout: 300
     max_retries: 3
     retry_backoff: 2.0
@@ -55,10 +55,10 @@ checkpoint:
     enabled: true
     checkpoint_file: /lus/flare/projects/FRAME-IDP/ogokdemir/data/exaforge_data/test_data_cards/checkpoint.json
 
-max_items: 128  # test mode — remove or set to 0 to process all papers
+max_items: 0  # test mode — remove or set to 0 to process all papers
 
 # Number of items loaded from disk at one time.
 # Each batch is fully processed and flushed before the next is loaded.
 # Controls memory independently of max_concurrent_requests.
 # For production (58k papers, no max_items): set to 1000–2000 and remove max_items.
-batch_size: 64
+batch_size: 1536

--- a/configs/task_configs/model_card_extract_test.yaml
+++ b/configs/task_configs/model_card_extract_test.yaml
@@ -11,7 +11,7 @@ aegis:
     config_path: /home/ogokdemir/ExaForge/configs/aegis_configs/single_file.yaml
     auto_launch: true
     wait_for_endpoints: true
-    endpoints_file: /home/ogokdemir/ExaForge/aegis_endpoints.txt
+    endpoints_file: /home/ogokdemir/ExaForge/local_runs/aegis_endpoints.txt
 
 task:
     name: card_extraction

--- a/src/exaforge/aegis_bridge.py
+++ b/src/exaforge/aegis_bridge.py
@@ -65,6 +65,7 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     from aegis.config import load_config as load_aegis_config
     from aegis.scheduler import (
         generate_pbs_script,
+        make_run_dir,
         submit_job,
         wait_for_endpoints,
     )
@@ -78,13 +79,20 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     logger.info("Loading Aegis config from %s", aegis_config_path)
     aegis_cfg = load_aegis_config(aegis_config_path)
 
+    # Generate a timestamped run directory. Aegis writes all artifacts there.
+    # launcher.py will also create local_runs/aegis_endpoints.txt as a symlink,
+    # so ExaForge's config.endpoints_file (pointing to local_runs/) needs no change.
+    run_dir = make_run_dir(config.endpoints_file.parent.parent)  # ExaForge project root
+    aegis_cfg.endpoints_file = str(run_dir / "aegis_endpoints.txt")
+    logger.info("Run directory: %s", run_dir)
+
     logger.info("Generating PBS script")
-    script = generate_pbs_script(aegis_cfg)
+    script = generate_pbs_script(aegis_cfg, run_dir=run_dir)
     script = script.replace("#PBS -N aegis", "#PBS -N exaforge", 1)
 
     hf_token = aegis_cfg.hf_token
     logger.info("Submitting PBS job")
-    job_id = submit_job(script, hf_token=hf_token)
+    job_id = submit_job(script, hf_token=hf_token, run_dir=run_dir)
 
     endpoints_file = str(config.endpoints_file)
     logger.info("Waiting for endpoints (job %s)", job_id)

--- a/src/exaforge/client.py
+++ b/src/exaforge/client.py
@@ -195,7 +195,7 @@ class InferenceClient:
             text = (
                 data.get("choices", [{}])[0]
                 .get("message", {})
-                .get("content", "")
+                .get("content") or ""
             )
             return ChatResponse(
                 text=text,

--- a/tests/test_aegis_bridge.py
+++ b/tests/test_aegis_bridge.py
@@ -84,7 +84,10 @@ class TestGetEndpointPool:
         aegis_config_mod = types.ModuleType("aegis.config")
         aegis_scheduler_mod = types.ModuleType("aegis.scheduler")
 
+        mock_make_run_dir = MagicMock(return_value=tmp_dir)
+
         aegis_config_mod.load_config = mock_load
+        aegis_scheduler_mod.make_run_dir = mock_make_run_dir
         aegis_scheduler_mod.generate_pbs_script = mock_generate
         aegis_scheduler_mod.submit_job = mock_submit
         aegis_scheduler_mod.wait_for_endpoints = mock_wait

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -39,6 +39,21 @@ class TestEndpointPool:
         pool = EndpointPool.from_file(p)
         assert len(pool.endpoints) == 2
 
+    def test_from_file_multi_port_same_host(self, tmp_dir: Path) -> None:
+        """Packed multi-instance endpoints (multiple ports per host) are all loaded."""
+        p = tmp_dir / "ep.txt"
+        p.write_text(
+            "nodeA:8000\nnodeA:8001\nnodeA:8002\n"
+            "nodeB:8000\nnodeB:8001\nnodeB:8002\n"
+        )
+        pool = EndpointPool.from_file(p)
+        assert len(pool.endpoints) == 6
+        urls = {ep.url for ep in pool.endpoints}
+        assert urls == {
+            "http://nodeA:8000", "http://nodeA:8001", "http://nodeA:8002",
+            "http://nodeB:8000", "http://nodeB:8001", "http://nodeB:8002",
+        }
+
 
 class TestSelection:
     def _pool(self) -> EndpointPool:


### PR DESCRIPTION
This branch equips ExaForge/Aegis pair with the ability to spawn multiple (vLLM) instances on the same node. Changes made in tandem on the Aegis side manage the number of requested nodes based on following formula:

PBS nodes:  instances /  (12/tensor_parallel_size) 