### PR TITLE
Feature/improved reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ all with Lustre-filesystem-aware I/O and built-in checkpointing.
 - **Lustre-aware I/O** — buffered JSONL writes, bulk reads, stripe tuning
   helpers, and atomic checkpointing designed for overwhelmed networked
   filesystems.
+- **Preprocessing** — CLI utility to pack large directories of small files into
+  batched JSONL shards before a run, drastically reducing Lustre metadata I/O.
 - **Checkpointing & resume** — interrupted jobs pick up where they left off.
 - **Monitoring** — Rich progress bars, throughput counters, error tracking,
   and structured JSONL log files.
@@ -159,6 +161,16 @@ reader:
     id_field: id        # JSON key for unique item IDs
 ```
 
+**ZIP archive** (`name: zip_text`):
+
+```yaml
+reader:
+    name: zip_text
+    input_dir: /lus/flare/projects/MyProject/preprocessed
+    glob_patterns: ["*.zip"]
+    stage_dir: /tmp     # Optional: extract archives here before reading
+```
+
 ### Writer section
 
 ```yaml
@@ -202,11 +214,55 @@ checkpoint:
 ## CLI reference
 
 ```
-exaforge run     --config <yaml>           Run a full inference pipeline
-exaforge launch  --config <yaml>           Launch Aegis endpoints only
-exaforge status  --config <yaml>           Show endpoint health + progress
-exaforge merge   <output_dir> [--output]   Merge shard JSONL files
+exaforge run        --config <yaml>              Run a full inference pipeline
+exaforge launch     --config <yaml>              Launch Aegis endpoints only
+exaforge status     --config <yaml>              Show endpoint health + progress
+exaforge merge      <output_dir> [--output]      Merge shard JSONL files
+exaforge preprocess --input-dir --output-dir     Pack files into JSONL/ZIP shards
 ```
+
+### Preprocessing large input directories
+
+When an input directory contains thousands of individual files (e.g. 58k `.mmd`
+papers), opening each file separately generates enormous Lustre metadata traffic —
+thousands of `stat`/`open`/`close` operations that serialise and saturate the
+metadata server. Preprocessing packs those files into a small number of large
+JSONL shards. At runtime, ExaForge opens ~30 shards instead of ~58 000 files,
+reducing metadata I/O by orders of magnitude.
+
+```bash
+# Pack 58k .mmd files into JSONL shards of 2000 items each, using 16 writer threads
+exaforge preprocess \
+    --input-dir  /lus/flare/projects/MyProject/papers \
+    --output-dir /lus/flare/projects/MyProject/preprocessed \
+    --glob       "*.mmd" \
+    --batch-size 2000 \
+    --workers    16
+
+# Then point the reader at the shards:
+# reader:
+#     name: jsonl
+#     input_dir: /lus/flare/projects/MyProject/preprocessed
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--input-dir` | `-i` | required | Source directory of text files |
+| `--output-dir` | `-o` | required | Where to write the shards |
+| `--format` | `-f` | `jsonl` | Output format: `jsonl` or `zip` |
+| `--batch-size` | `-b` | `1000` | Files packed per shard |
+| `--workers` | `-w` | `1` | Concurrent shard-writer threads |
+| `--glob` | `-g` | `*.txt` | Glob pattern(s) for source files (repeatable) |
+| `--base-name` | `-n` | `batch` | Shard filename prefix (`batch_0000.jsonl`) |
+| `--deduplicate` | `-d` | off | Remove duplicate paths before batching |
+
+Each JSONL shard line has the form:
+```json
+{"id": "<file_stem>", "text": "<file_contents>", "source_file": "<original_path>"}
+```
+
+The `jsonl` reader's `text_field` and `id_field` defaults (`text` / `id`) match
+this schema directly — no extra config needed.
 
 ### Examples
 
@@ -243,7 +299,8 @@ exaforge merge /lus/flare/projects/MyProject/output --output merged.jsonl
 | Module | Responsibility |
 |--------|---------------|
 | `config.py` | Pydantic config models with YAML serde |
-| `readers/` | Bulk-load input data (text files, JSONL) |
+| `preprocess.py` | Batch files into JSONL/ZIP shards for efficient Lustre I/O |
+| `readers/` | Bulk-load input data (text files, JSONL, ZIP archives) |
 | `writers/` | Buffered JSONL output with fsync |
 | `endpoints.py` | Load Aegis endpoints, health check, load balance |
 | `client.py` | Async HTTP client for OpenAI chat completions |

--- a/configs/aegis_configs/single_file.yaml
+++ b/configs/aegis_configs/single_file.yaml
@@ -13,13 +13,13 @@ aegis_env: /home/ogokdemir/.conda/envs/exaforge-env/
 models:
   - model: openai/gpt-oss-120b
     #PBS will request 64 / (12 / tensor_parallel_size) nodes on Aurora. Ensure divisibility.
-    instances: 96
+    instances: 384
     tensor_parallel_size: 4
     model_source: /flare/datasets/model-weights/hub/models--openai--gpt-oss-120b
     download_weights: false
     extra_vllm_args:
       - --max-model-len
-      - "65536" # this should fit the full paper and the ~4k token paper card.
+      - "96000" # this should fit the full paper and the ~4k token paper card.
 
 wait: true
 bench: false

--- a/configs/task_configs/data_card_extract_test.yaml
+++ b/configs/task_configs/data_card_extract_test.yaml
@@ -23,15 +23,15 @@ task:
     max_tokens: 4000 # paper should not be longer than 
 
 reader:
-    name: text_directory
-    input_dir: /lus/flare/projects/LUCID/ogokdemir/data/SC/SC-Parsed
-    glob_patterns:
-        - "*.mmd"
+    name: jsonl
+    input_dir: /lus/flare/projects/FRAME-IDP/ogokdemir/data/exaforge_data/batched
+    text_field: text
+    id_field: id
 
 writer:
     name: jsonl
     output_dir: /lus/flare/projects/FRAME-IDP/ogokdemir/data/exaforge_data/test_data_cards
-    buffer_size: 8
+    buffer_size: 1536 # number of individual completed vLLM inferences to buffer before writing to disk.
     base_name: data_cards
 
 client:
@@ -40,7 +40,7 @@ client:
     # Global in-flight request cap across ALL endpoints combined.
     # Rule of thumb for production: num_endpoints × desired_queue_depth
     # e.g. 12 endpoints × 16 = 192. For this test run 64 is fine.
-    max_concurrent_requests: 1536 # 1536 = 96 (instances) * 16 (requests per instance)
+    max_concurrent_requests: 6144 # 384 (instances) * 16 (requests per instance)
     timeout: 300
     max_retries: 3
     retry_backoff: 2.0
@@ -48,7 +48,7 @@ client:
 
 monitor:
     log_file: /lus/flare/projects/FRAME-IDP/ogokdemir/data/exaforge_data/test_data_cards/run.log
-    progress_interval: 30
+    progress_interval: 30 #seconds
     enable_rich: true
 
 checkpoint:

--- a/src/exaforge/cli.py
+++ b/src/exaforge/cli.py
@@ -216,7 +216,7 @@ def preprocess(
     batch_size: int = typer.Option(
         1000,
         "--batch-size",
-        "-K",
+        "-b",
         help="Number of items per output shard",
     ),
     glob_patterns: Optional[List[str]] = typer.Option(
@@ -226,7 +226,7 @@ def preprocess(
         help="Glob pattern(s) for source files (repeatable). Default: '*.txt'",
     ),
     base_name: str = typer.Option(
-        "batch", "--base-name", "-b", help="Prefix for shard filenames"
+        "batch", "--base-name", "-n", help="Prefix for shard filenames"
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:

--- a/src/exaforge/cli.py
+++ b/src/exaforge/cli.py
@@ -228,6 +228,13 @@ def preprocess(
     base_name: str = typer.Option(
         "batch", "--base-name", "-n", help="Prefix for shard filenames"
     ),
+    deduplicate: bool = typer.Option(
+        False,
+        "--deduplicate",
+        "-d",
+        help="Deduplicate files",
+        show_default=True,
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:
     """Batch text files into JSONL shards or ZIP archives for fast I/O.
@@ -258,6 +265,7 @@ def preprocess(
             glob_patterns=glob_patterns,
             batch_size=batch_size,
             base_name=base_name,
+            deduplicate=deduplicate,
         )
     elif fmt == "zip":
         total = preprocess_to_zip(
@@ -266,6 +274,7 @@ def preprocess(
             glob_patterns=glob_patterns,
             batch_size=batch_size,
             base_name=base_name,
+            deduplicate=deduplicate,
         )
     else:
         console.print(f"[red]Unknown format: {fmt!r}. Use 'jsonl' or 'zip'.[/red]")

--- a/src/exaforge/cli.py
+++ b/src/exaforge/cli.py
@@ -235,6 +235,13 @@ def preprocess(
         help="Deduplicate files",
         show_default=True,
     ),
+    workers: int = typer.Option(
+        1,
+        "--workers",
+        "-w",
+        help="Number of concurrent shard-writer threads",
+        show_default=True,
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:
     """Batch text files into JSONL shards or ZIP archives for fast I/O.
@@ -266,6 +273,7 @@ def preprocess(
             batch_size=batch_size,
             base_name=base_name,
             deduplicate=deduplicate,
+            workers=workers,
         )
     elif fmt == "zip":
         total = preprocess_to_zip(
@@ -275,6 +283,7 @@ def preprocess(
             batch_size=batch_size,
             base_name=base_name,
             deduplicate=deduplicate,
+            workers=workers,
         )
     else:
         console.print(f"[red]Unknown format: {fmt!r}. Use 'jsonl' or 'zip'.[/red]")

--- a/src/exaforge/cli.py
+++ b/src/exaforge/cli.py
@@ -6,6 +6,7 @@ Provides the ``exaforge`` console entry point with subcommands:
 * ``launch``  — launch Aegis endpoints only
 * ``status``  — show endpoint health
 * ``merge``   — merge shard JSONL files into one
+* ``preprocess`` — batch files into JSONL shards or ZIP archives
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from rich.console import Console
@@ -191,6 +192,88 @@ def merge(
     console.print(
         f"[green]Merged {len(shards)} shard(s), "
         f"{total_lines} records -> {output_file}[/green]"
+    )
+
+
+# ------------------------------------------------------------------
+# preprocess
+# ------------------------------------------------------------------
+
+@app.command()
+def preprocess(
+    input_dir: Path = typer.Option(
+        ..., "--input-dir", "-i", help="Directory of source text files"
+    ),
+    output_dir: Path = typer.Option(
+        ..., "--output-dir", "-o", help="Where to write preprocessed shards"
+    ),
+    fmt: str = typer.Option(
+        "jsonl",
+        "--format",
+        "-f",
+        help="Output format: 'jsonl' or 'zip'",
+    ),
+    batch_size: int = typer.Option(
+        1000,
+        "--batch-size",
+        "-K",
+        help="Number of items per output shard",
+    ),
+    glob_patterns: Optional[List[str]] = typer.Option(
+        None,
+        "--glob",
+        "-g",
+        help="Glob pattern(s) for source files (repeatable). Default: '*.txt'",
+    ),
+    base_name: str = typer.Option(
+        "batch", "--base-name", "-b", help="Prefix for shard filenames"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Batch text files into JSONL shards or ZIP archives for fast I/O.
+
+    Converts a directory of many small files (e.g. 58k .mmd papers on
+    Lustre) into a handful of larger shards that are dramatically faster
+    to read at runtime.
+
+    Examples::
+
+        # Pack 58k .mmd files into JSONL shards of 2000 each
+        exaforge preprocess -i /data/papers -o /data/preprocessed -g '*.mmd' -K 2000
+
+        # Pack into ZIP archives for staging to /tmp
+        exaforge preprocess -i /data/papers -o /data/preprocessed -g '*.mmd' -f zip -K 2000
+    """
+    _setup_logging(verbose)
+
+    if glob_patterns is None:
+        glob_patterns = ["*.txt"]
+
+    from exaforge.preprocess import preprocess_to_jsonl, preprocess_to_zip
+
+    if fmt == "jsonl":
+        total = preprocess_to_jsonl(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            glob_patterns=glob_patterns,
+            batch_size=batch_size,
+            base_name=base_name,
+        )
+    elif fmt == "zip":
+        total = preprocess_to_zip(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            glob_patterns=glob_patterns,
+            batch_size=batch_size,
+            base_name=base_name,
+        )
+    else:
+        console.print(f"[red]Unknown format: {fmt!r}. Use 'jsonl' or 'zip'.[/red]")
+        raise typer.Exit(1)
+
+    console.print(
+        f"[bold green]Preprocessed {total} file(s) into "
+        f"{fmt.upper()} shards in {output_dir}[/bold green]"
     )
 
 

--- a/src/exaforge/config.py
+++ b/src/exaforge/config.py
@@ -168,7 +168,37 @@ class JsonlReaderConfig(BaseConfig):
         return v.resolve()
 
 
-ReaderConfigs = Union[TextDirectoryReaderConfig, JsonlReaderConfig]
+class ZipTextReaderConfig(BaseConfig):
+    """Read text files from batched ZIP archives.
+
+    Produced by ``exaforge preprocess --format zip``.  When *stage_dir*
+    is set, archives are extracted to fast node-local storage before
+    reading (e.g. ``/tmp`` on Aurora).
+    """
+
+    name: Literal["zip_text"] = "zip_text"  # type: ignore[assignment]
+    input_dir: Path = Path(".")
+    glob_patterns: list[str] = Field(default=["*.zip"])
+    stage_dir: Optional[Path] = Field(
+        default=None,
+        description=(
+            "If set, archives are extracted here before reading. "
+            "Use a fast local filesystem (e.g. /tmp) for best performance."
+        ),
+    )
+
+    @field_validator("input_dir")
+    @classmethod
+    def _resolve_input(cls, v: Path) -> Path:
+        return v.resolve()
+
+    @field_validator("stage_dir")
+    @classmethod
+    def _resolve_stage(cls, v: Optional[Path]) -> Optional[Path]:
+        return v.resolve() if v is not None else None
+
+
+ReaderConfigs = Union[TextDirectoryReaderConfig, JsonlReaderConfig, ZipTextReaderConfig]
 
 
 # ---------------------------------------------------------------------------

--- a/src/exaforge/preprocess.py
+++ b/src/exaforge/preprocess.py
@@ -1,0 +1,186 @@
+"""Preprocessing utilities for ExaForge.
+
+Converts a directory of individual text files into batched JSONL or ZIP
+archives for more efficient I/O on parallel file systems like Lustre.
+
+**JSONL mode** — packs K files per ``.jsonl`` shard::
+
+    {"id": "file_stem", "text": "...", "source_file": "/original/path.mmd"}
+
+**ZIP mode** — packs K files per ``.zip`` archive, preserving original
+filenames.  At runtime the :class:`ZipTextReader` can optionally stage
+archives to fast node-local storage (e.g. ``/tmp``) before reading.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _discover_files(
+    input_dir: Path,
+    glob_patterns: list[str],
+) -> list[Path]:
+    """Collect and deduplicate matching files in deterministic order."""
+    if not input_dir.is_dir():
+        raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
+
+    paths: list[Path] = []
+    for pattern in glob_patterns:
+        paths.extend(sorted(input_dir.glob(pattern)))
+
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for p in paths:
+        if p not in seen and p.is_file():
+            seen.add(p)
+            unique.append(p)
+
+    return unique
+
+
+def preprocess_to_jsonl(
+    input_dir: Path,
+    output_dir: Path,
+    glob_patterns: list[str],
+    batch_size: int = 1000,
+    *,
+    base_name: str = "batch",
+) -> int:
+    """Pack text files into batched JSONL shards.
+
+    Parameters
+    ----------
+    input_dir : Path
+        Directory containing source text files.
+    output_dir : Path
+        Where to write the JSONL shard files.
+    glob_patterns : list[str]
+        Glob patterns to match source files (e.g. ``["*.mmd"]``).
+    batch_size : int
+        Number of records per JSONL file.
+    base_name : str
+        Prefix for shard filenames (``{base_name}_{0000}.jsonl``).
+
+    Returns
+    -------
+    int
+        Total number of files packed.
+    """
+    files = _discover_files(input_dir, glob_patterns)
+    if not files:
+        logger.warning("No files matched in %s", input_dir)
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    total = len(files)
+    shard_idx = 0
+    written = 0
+
+    for start in range(0, total, batch_size):
+        batch = files[start : start + batch_size]
+        shard_path = output_dir / f"{base_name}_{shard_idx:04d}.jsonl"
+
+        with open(shard_path, "w", encoding="utf-8") as fp:
+            for path in batch:
+                try:
+                    text = path.read_text(encoding="utf-8", errors="replace")
+                except OSError as exc:
+                    logger.warning("Skipping %s: %s", path, exc)
+                    continue
+
+                record = {
+                    "id": path.stem,
+                    "text": text,
+                    "source_file": str(path),
+                }
+                fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+                written += 1
+
+        logger.info(
+            "Shard %d: %d items -> %s", shard_idx, len(batch), shard_path
+        )
+        shard_idx += 1
+
+    logger.info(
+        "Preprocessing complete: %d files -> %d JSONL shard(s) in %s",
+        written,
+        shard_idx,
+        output_dir,
+    )
+    return written
+
+
+def preprocess_to_zip(
+    input_dir: Path,
+    output_dir: Path,
+    glob_patterns: list[str],
+    batch_size: int = 1000,
+    *,
+    base_name: str = "batch",
+) -> int:
+    """Pack text files into batched ZIP archives.
+
+    Each archive contains up to *batch_size* files stored with their
+    original basenames.  At runtime, the ZipTextReader can extract them
+    to fast node-local storage for low-latency reads.
+
+    Parameters
+    ----------
+    input_dir : Path
+        Directory containing source text files.
+    output_dir : Path
+        Where to write the ZIP archive files.
+    glob_patterns : list[str]
+        Glob patterns to match source files.
+    batch_size : int
+        Number of files per ZIP archive.
+    base_name : str
+        Prefix for archive filenames (``{base_name}_{0000}.zip``).
+
+    Returns
+    -------
+    int
+        Total number of files packed.
+    """
+    files = _discover_files(input_dir, glob_patterns)
+    if not files:
+        logger.warning("No files matched in %s", input_dir)
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    total = len(files)
+    shard_idx = 0
+    written = 0
+
+    for start in range(0, total, batch_size):
+        batch = files[start : start + batch_size]
+        archive_path = output_dir / f"{base_name}_{shard_idx:04d}.zip"
+
+        with zipfile.ZipFile(
+            archive_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as zf:
+            for path in batch:
+                try:
+                    zf.write(path, arcname=path.name)
+                    written += 1
+                except OSError as exc:
+                    logger.warning("Skipping %s: %s", path, exc)
+
+        logger.info(
+            "Archive %d: %d items -> %s", shard_idx, len(batch), archive_path
+        )
+        shard_idx += 1
+
+    logger.info(
+        "Preprocessing complete: %d files -> %d ZIP archive(s) in %s",
+        written,
+        shard_idx,
+        output_dir,
+    )
+    return written

--- a/src/exaforge/preprocess.py
+++ b/src/exaforge/preprocess.py
@@ -19,6 +19,7 @@ import logging
 import zipfile
 from pathlib import Path
 import sys
+from math import ceil
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
@@ -41,8 +42,12 @@ def _discover_files(
         paths.extend(input_dir.glob(pattern))
 
     print(f"Found {len(paths)} files", file=sys.stdout, flush=True)
-
-    if deduplicate:
+    
+    if not deduplicate:
+        print(f"Skipping deduplication for {len(paths)} files", file=sys.stdout, flush=True)
+        return paths
+    
+    else:
         print(f"Deduplicating files", file=sys.stdout, flush=True)
         seen: set[Path] = set()
         unique: list[Path] = []
@@ -56,7 +61,6 @@ def _discover_files(
 
         return unique
 
-    return paths
 
 def preprocess_to_jsonl(
     input_dir: Path,
@@ -97,7 +101,7 @@ def preprocess_to_jsonl(
     shard_idx = 0
     written = 0
 
-    for start in tqdm(range(0, total, batch_size), total=total, desc="Preprocessing to JSONL"):
+    for start in tqdm(range(0, total, batch_size), total=ceil(total / batch_size), desc="Preprocessing to JSONL"):
         batch = files[start : start + batch_size]
         shard_path = output_dir / f"{base_name}_{shard_idx:04d}.jsonl"
 
@@ -174,7 +178,7 @@ def preprocess_to_zip(
     shard_idx = 0
     written = 0
 
-    for start in tqdm(range(0, total, batch_size), total=total, desc="Preprocessing to ZIP"):
+    for start in tqdm(range(0, total, batch_size), total=ceil(total / batch_size), desc="Preprocessing to ZIP"):
         batch = files[start : start + batch_size]
         archive_path = output_dir / f"{base_name}_{shard_idx:04d}.zip"
 

--- a/src/exaforge/preprocess.py
+++ b/src/exaforge/preprocess.py
@@ -18,6 +18,8 @@ import json
 import logging
 import zipfile
 from pathlib import Path
+import sys
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -26,13 +28,18 @@ def _discover_files(
     input_dir: Path,
     glob_patterns: list[str],
 ) -> list[Path]:
+    print(f"Discovering files in {input_dir} with patterns {glob_patterns}",
+    file=sys.stdout,
+    flush=True)
     """Collect and deduplicate matching files in deterministic order."""
     if not input_dir.is_dir():
         raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
 
     paths: list[Path] = []
     for pattern in glob_patterns:
-        paths.extend(sorted(input_dir.glob(pattern)))
+        paths.extend(input_dir.glob(pattern))
+
+    print(f"Found {len(paths)} files", file=sys.stdout, flush=True)
 
     seen: set[Path] = set()
     unique: list[Path] = []
@@ -40,6 +47,9 @@ def _discover_files(
         if p not in seen and p.is_file():
             seen.add(p)
             unique.append(p)
+
+    print(f"Removed {len(paths) - len(unique)} duplicate files", file=sys.stdout, flush=True)
+    print(f"Batching {len(unique)} unique files", file=sys.stdout, flush=True)
 
     return unique
 
@@ -82,7 +92,7 @@ def preprocess_to_jsonl(
     shard_idx = 0
     written = 0
 
-    for start in range(0, total, batch_size):
+    for start in tqdm(range(0, total, batch_size), total=total, desc="Preprocessing to JSONL"):
         batch = files[start : start + batch_size]
         shard_path = output_dir / f"{base_name}_{shard_idx:04d}.jsonl"
 
@@ -158,7 +168,7 @@ def preprocess_to_zip(
     shard_idx = 0
     written = 0
 
-    for start in range(0, total, batch_size):
+    for start in tqdm(range(0, total, batch_size), total=total, desc="Preprocessing to ZIP"):
         batch = files[start : start + batch_size]
         archive_path = output_dir / f"{base_name}_{shard_idx:04d}.zip"
 

--- a/src/exaforge/preprocess.py
+++ b/src/exaforge/preprocess.py
@@ -10,20 +10,31 @@ archives for more efficient I/O on parallel file systems like Lustre.
 **ZIP mode** — packs K files per ``.zip`` archive, preserving original
 filenames.  At runtime the :class:`ZipTextReader` can optionally stage
 archives to fast node-local storage (e.g. ``/tmp``) before reading.
+
+Both modes support concurrent shard writing via a thread pool
+(``workers`` parameter / ``-w`` CLI flag).  Each worker independently
+reads its assigned files and writes one shard, so the thread pool
+saturates Lustre I/O bandwidth across multiple concurrent streams.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import zipfile
-from pathlib import Path
 import sys
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from math import ceil
+from pathlib import Path
+
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
 
 def _discover_files(
     input_dir: Path,
@@ -31,9 +42,8 @@ def _discover_files(
     deduplicate: bool = False,
 ) -> list[Path]:
     print(f"Discovering files in {input_dir} with patterns {glob_patterns}",
-    file=sys.stdout,
-    flush=True)
-    """Collect and deduplicate matching files in deterministic order."""
+          file=sys.stdout, flush=True)
+    """Collect matching files in deterministic order, optionally deduplicated."""
     if not input_dir.is_dir():
         raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
 
@@ -42,25 +52,72 @@ def _discover_files(
         paths.extend(input_dir.glob(pattern))
 
     print(f"Found {len(paths)} files", file=sys.stdout, flush=True)
-    
+
     if not deduplicate:
-        print(f"Skipping deduplication for {len(paths)} files", file=sys.stdout, flush=True)
+        print(f"Skipping deduplication for {len(paths)} files",
+              file=sys.stdout, flush=True)
         return paths
-    
-    else:
-        print(f"Deduplicating files", file=sys.stdout, flush=True)
-        seen: set[Path] = set()
-        unique: list[Path] = []
-        for p in paths:
-            if p not in seen and p.is_file():
-                seen.add(p)
-                unique.append(p)
 
-        print(f"Removed {len(paths) - len(unique)} duplicate files", file=sys.stdout, flush=True)
-        print(f"Batching {len(unique)} unique files", file=sys.stdout, flush=True)
+    print("Deduplicating files", file=sys.stdout, flush=True)
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for p in paths:
+        if p not in seen and p.is_file():
+            seen.add(p)
+            unique.append(p)
 
-        return unique
+    print(f"Removed {len(paths) - len(unique)} duplicate files",
+          file=sys.stdout, flush=True)
+    print(f"Batching {len(unique)} unique files", file=sys.stdout, flush=True)
+    return unique
 
+
+# ---------------------------------------------------------------------------
+# Per-shard worker functions (called inside threads)
+# ---------------------------------------------------------------------------
+
+def _write_jsonl_shard(
+    shard_path: Path,
+    batch: list[Path],
+) -> int:
+    """Read *batch* files and write one JSONL shard.  Returns records written."""
+    written = 0
+    with open(shard_path, "w", encoding="utf-8") as fp:
+        for path in batch:
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                logger.warning("Skipping %s: %s", path, exc)
+                continue
+            record = {
+                "id": path.stem,
+                "text": text,
+                "source_file": str(path),
+            }
+            fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+            written += 1
+    return written
+
+
+def _write_zip_shard(
+    archive_path: Path,
+    batch: list[Path],
+) -> int:
+    """Pack *batch* files into one ZIP archive.  Returns files written."""
+    written = 0
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in batch:
+            try:
+                zf.write(path, arcname=path.name)
+                written += 1
+            except OSError as exc:
+                logger.warning("Skipping %s: %s", path, exc)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def preprocess_to_jsonl(
     input_dir: Path,
@@ -68,6 +125,7 @@ def preprocess_to_jsonl(
     glob_patterns: list[str],
     batch_size: int = 1000,
     deduplicate: bool = False,
+    workers: int = 1,
     *,
     base_name: str = "batch",
 ) -> int:
@@ -83,13 +141,18 @@ def preprocess_to_jsonl(
         Glob patterns to match source files (e.g. ``["*.mmd"]``).
     batch_size : int
         Number of records per JSONL file.
+    deduplicate : bool
+        Remove duplicate paths before batching.
+    workers : int
+        Number of concurrent writer threads.  Each thread writes one
+        shard at a time.  Use ``1`` for serial behaviour.
     base_name : str
         Prefix for shard filenames (``{base_name}_{0000}.jsonl``).
 
     Returns
     -------
     int
-        Total number of files packed.
+        Total number of records written.
     """
     files = _discover_files(input_dir, glob_patterns, deduplicate)
     if not files:
@@ -98,39 +161,35 @@ def preprocess_to_jsonl(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     total = len(files)
-    shard_idx = 0
-    written = 0
+    num_shards = ceil(total / batch_size)
 
-    for start in tqdm(range(0, total, batch_size), total=ceil(total / batch_size), desc="Preprocessing to JSONL"):
-        batch = files[start : start + batch_size]
-        shard_path = output_dir / f"{base_name}_{shard_idx:04d}.jsonl"
-
-        with open(shard_path, "w", encoding="utf-8") as fp:
-            for path in batch:
-                try:
-                    text = path.read_text(encoding="utf-8", errors="replace")
-                except OSError as exc:
-                    logger.warning("Skipping %s: %s", path, exc)
-                    continue
-
-                record = {
-                    "id": path.stem,
-                    "text": text,
-                    "source_file": str(path),
-                }
-                fp.write(json.dumps(record, ensure_ascii=False) + "\n")
-                written += 1
-
-        logger.info(
-            "Shard %d: %d items -> %s", shard_idx, len(batch), shard_path
+    # Build work items: (shard_idx, shard_path, batch_slice)
+    work = [
+        (
+            shard_idx,
+            output_dir / f"{base_name}_{shard_idx:04d}.jsonl",
+            files[start : start + batch_size],
         )
-        shard_idx += 1
+        for shard_idx, start in enumerate(range(0, total, batch_size))
+    ]
+
+    written = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_write_jsonl_shard, shard_path, batch): shard_idx
+            for shard_idx, shard_path, batch in work
+        }
+        with tqdm(total=num_shards, desc="Preprocessing to JSONL") as pbar:
+            for future in as_completed(futures):
+                shard_idx = futures[future]
+                count = future.result()
+                written += count
+                logger.info("Shard %d: %d records written", shard_idx, count)
+                pbar.update(1)
 
     logger.info(
         "Preprocessing complete: %d files -> %d JSONL shard(s) in %s",
-        written,
-        shard_idx,
-        output_dir,
+        written, num_shards, output_dir,
     )
     return written
 
@@ -141,14 +200,11 @@ def preprocess_to_zip(
     glob_patterns: list[str],
     batch_size: int = 1000,
     deduplicate: bool = False,
+    workers: int = 1,
     *,
     base_name: str = "batch",
 ) -> int:
     """Pack text files into batched ZIP archives.
-
-    Each archive contains up to *batch_size* files stored with their
-    original basenames.  At runtime, the ZipTextReader can extract them
-    to fast node-local storage for low-latency reads.
 
     Parameters
     ----------
@@ -160,6 +216,10 @@ def preprocess_to_zip(
         Glob patterns to match source files.
     batch_size : int
         Number of files per ZIP archive.
+    deduplicate : bool
+        Remove duplicate paths before batching.
+    workers : int
+        Number of concurrent writer threads.
     base_name : str
         Prefix for archive filenames (``{base_name}_{0000}.zip``).
 
@@ -175,32 +235,33 @@ def preprocess_to_zip(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     total = len(files)
-    shard_idx = 0
-    written = 0
+    num_shards = ceil(total / batch_size)
 
-    for start in tqdm(range(0, total, batch_size), total=ceil(total / batch_size), desc="Preprocessing to ZIP"):
-        batch = files[start : start + batch_size]
-        archive_path = output_dir / f"{base_name}_{shard_idx:04d}.zip"
-
-        with zipfile.ZipFile(
-            archive_path, "w", compression=zipfile.ZIP_DEFLATED
-        ) as zf:
-            for path in batch:
-                try:
-                    zf.write(path, arcname=path.name)
-                    written += 1
-                except OSError as exc:
-                    logger.warning("Skipping %s: %s", path, exc)
-
-        logger.info(
-            "Archive %d: %d items -> %s", shard_idx, len(batch), archive_path
+    work = [
+        (
+            shard_idx,
+            output_dir / f"{base_name}_{shard_idx:04d}.zip",
+            files[start : start + batch_size],
         )
-        shard_idx += 1
+        for shard_idx, start in enumerate(range(0, total, batch_size))
+    ]
+
+    written = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_write_zip_shard, archive_path, batch): shard_idx
+            for shard_idx, archive_path, batch in work
+        }
+        with tqdm(total=num_shards, desc="Preprocessing to ZIP") as pbar:
+            for future in as_completed(futures):
+                shard_idx = futures[future]
+                count = future.result()
+                written += count
+                logger.info("Archive %d: %d files written", shard_idx, count)
+                pbar.update(1)
 
     logger.info(
         "Preprocessing complete: %d files -> %d ZIP archive(s) in %s",
-        written,
-        shard_idx,
-        output_dir,
+        written, num_shards, output_dir,
     )
     return written

--- a/src/exaforge/preprocess.py
+++ b/src/exaforge/preprocess.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 def _discover_files(
     input_dir: Path,
     glob_patterns: list[str],
+    deduplicate: bool = False,
 ) -> list[Path]:
     print(f"Discovering files in {input_dir} with patterns {glob_patterns}",
     file=sys.stdout,
@@ -41,24 +42,28 @@ def _discover_files(
 
     print(f"Found {len(paths)} files", file=sys.stdout, flush=True)
 
-    seen: set[Path] = set()
-    unique: list[Path] = []
-    for p in paths:
-        if p not in seen and p.is_file():
-            seen.add(p)
-            unique.append(p)
+    if deduplicate:
+        print(f"Deduplicating files", file=sys.stdout, flush=True)
+        seen: set[Path] = set()
+        unique: list[Path] = []
+        for p in paths:
+            if p not in seen and p.is_file():
+                seen.add(p)
+                unique.append(p)
 
-    print(f"Removed {len(paths) - len(unique)} duplicate files", file=sys.stdout, flush=True)
-    print(f"Batching {len(unique)} unique files", file=sys.stdout, flush=True)
+        print(f"Removed {len(paths) - len(unique)} duplicate files", file=sys.stdout, flush=True)
+        print(f"Batching {len(unique)} unique files", file=sys.stdout, flush=True)
 
-    return unique
+        return unique
 
+    return paths
 
 def preprocess_to_jsonl(
     input_dir: Path,
     output_dir: Path,
     glob_patterns: list[str],
     batch_size: int = 1000,
+    deduplicate: bool = False,
     *,
     base_name: str = "batch",
 ) -> int:
@@ -82,7 +87,7 @@ def preprocess_to_jsonl(
     int
         Total number of files packed.
     """
-    files = _discover_files(input_dir, glob_patterns)
+    files = _discover_files(input_dir, glob_patterns, deduplicate)
     if not files:
         logger.warning("No files matched in %s", input_dir)
         return 0
@@ -131,6 +136,7 @@ def preprocess_to_zip(
     output_dir: Path,
     glob_patterns: list[str],
     batch_size: int = 1000,
+    deduplicate: bool = False,
     *,
     base_name: str = "batch",
 ) -> int:
@@ -158,7 +164,7 @@ def preprocess_to_zip(
     int
         Total number of files packed.
     """
-    files = _discover_files(input_dir, glob_patterns)
+    files = _discover_files(input_dir, glob_patterns, deduplicate)
     if not files:
         logger.warning("No files matched in %s", input_dir)
         return 0

--- a/src/exaforge/readers/__init__.py
+++ b/src/exaforge/readers/__init__.py
@@ -8,23 +8,31 @@ from __future__ import annotations
 
 from typing import Union
 
-from exaforge.config import JsonlReaderConfig, ReaderConfigs, TextDirectoryReaderConfig
+from exaforge.config import (
+    JsonlReaderConfig,
+    ReaderConfigs,
+    TextDirectoryReaderConfig,
+    ZipTextReaderConfig,
+)
 
 from .base import BaseReader, InputItem
 from .jsonl import JsonlReader
 from .text_directory import TextDirectoryReader
+from .zip_text import ZipTextReader
 
 __all__ = [
     "BaseReader",
     "InputItem",
     "JsonlReader",
     "TextDirectoryReader",
+    "ZipTextReader",
     "get_reader",
 ]
 
 _STRATEGIES: dict[str, tuple[type, type[BaseReader]]] = {
     "text_directory": (TextDirectoryReaderConfig, TextDirectoryReader),
     "jsonl": (JsonlReaderConfig, JsonlReader),
+    "zip_text": (ZipTextReaderConfig, ZipTextReader),
 }
 
 

--- a/src/exaforge/readers/jsonl.py
+++ b/src/exaforge/readers/jsonl.py
@@ -4,25 +4,45 @@ Each line of a JSONL file is expected to be a JSON object.  The reader
 extracts the ``text`` and ``id`` fields (configurable) and carries the
 full original record as metadata so it can be merged back into the
 output.
+
+Supports the two-phase scan / read_by_ids workflow so the orchestrator
+can discover IDs cheaply, filter via the checkpoint, and only parse the
+lines that will actually be processed.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+from typing import Optional
 
 from exaforge.config import JsonlReaderConfig
 
 from .base import BaseReader, InputItem
 
+logger = logging.getLogger(__name__)
+
 
 class JsonlReader(BaseReader):
-    """Load JSONL files from a directory, one InputItem per JSON line."""
+    """Load JSONL files from a directory, one InputItem per JSON line.
+
+    The reader caches a lightweight index on first access (mapping
+    item IDs to ``(file_path, line_number)`` positions) so that
+    :meth:`scan` is cheap and :meth:`read_by_ids` only parses the
+    lines it needs.
+    """
 
     def __init__(self, config: JsonlReaderConfig) -> None:
         self.config = config
+        self._index: Optional[dict[str, tuple[Path, int]]] = None
 
-    def read(self) -> list[InputItem]:
+    # ------------------------------------------------------------------
+    # Discovery (cached)
+    # ------------------------------------------------------------------
+
+    def _discover_files(self) -> list[Path]:
+        """Return deduplicated, sorted list of matching JSONL files."""
         input_dir = self.config.input_dir
         if not input_dir.is_dir():
             raise FileNotFoundError(
@@ -39,11 +59,77 @@ class JsonlReader(BaseReader):
             if p not in seen and p.is_file():
                 seen.add(p)
                 unique.append(p)
+        return unique
 
-        items: list[InputItem] = []
-        for p in unique:
+    def _build_index(self) -> dict[str, tuple[Path, int]]:
+        """Build a mapping of ``{item_id: (file_path, line_number)}``.
+
+        This reads every file line-by-line but only parses the JSON
+        enough to extract the ``id_field``.  Content is NOT retained,
+        so memory stays low for large datasets.
+        """
+        if self._index is not None:
+            return self._index
+
+        files = self._discover_files()
+        index: dict[str, tuple[Path, int]] = {}
+
+        for p in files:
             raw = p.read_text(encoding="utf-8", errors="replace")
             for line_no, line in enumerate(raw.splitlines(), start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                item_id = str(
+                    record.get(
+                        self.config.id_field, f"{p.stem}:{line_no}"
+                    )
+                )
+                index[item_id] = (p, line_no)
+
+        logger.info("Indexed %d items from %d JSONL file(s)", len(index), len(files))
+        self._index = index
+        return index
+
+    # ------------------------------------------------------------------
+    # Two-phase API (preferred by the orchestrator)
+    # ------------------------------------------------------------------
+
+    def scan(self) -> list[str]:
+        """Return item IDs without loading text content."""
+        return list(self._build_index().keys())
+
+    def read_by_ids(self, ids: set[str]) -> list[InputItem]:
+        """Load only items whose ID is in *ids*.
+
+        Re-reads the JSONL files but skips lines whose ID is not in the
+        requested set, avoiding full deserialization of every record.
+        """
+        index = self._build_index()
+        # Group requested IDs by file for sequential I/O
+        by_file: dict[Path, set[int]] = {}
+        for item_id in ids:
+            entry = index.get(item_id)
+            if entry is None:
+                logger.warning("ID %r not found in index — skipping", item_id)
+                continue
+            fpath, line_no = entry
+            by_file.setdefault(fpath, set()).add(line_no)
+
+        items: list[InputItem] = []
+        loaded = 0
+        target = len(ids)
+
+        for fpath, line_numbers in by_file.items():
+            raw = fpath.read_text(encoding="utf-8", errors="replace")
+            for line_no, line in enumerate(raw.splitlines(), start=1):
+                if line_no not in line_numbers:
+                    continue
                 line = line.strip()
                 if not line:
                     continue
@@ -55,7 +141,7 @@ class JsonlReader(BaseReader):
                 text = str(record.get(self.config.text_field, ""))
                 item_id = str(
                     record.get(
-                        self.config.id_field, f"{p.stem}:{line_no}"
+                        self.config.id_field, f"{fpath.stem}:{line_no}"
                     )
                 )
                 items.append(
@@ -63,10 +149,22 @@ class JsonlReader(BaseReader):
                         id=item_id,
                         text=text,
                         metadata={
-                            "source_file": str(p),
+                            "source_file": str(fpath),
                             "line_number": line_no,
                             "original_record": record,
                         },
                     )
                 )
+                loaded += 1
+                if loaded % 500 == 0:
+                    logger.info("Loaded %d / %d items …", loaded, target)
+
         return items
+
+    # ------------------------------------------------------------------
+    # Legacy full-read API (BaseReader interface)
+    # ------------------------------------------------------------------
+
+    def read(self) -> list[InputItem]:
+        all_ids = set(self._build_index().keys())
+        return self.read_by_ids(all_ids)

--- a/src/exaforge/readers/zip_text.py
+++ b/src/exaforge/readers/zip_text.py
@@ -1,0 +1,257 @@
+"""Reader that loads text files from batched ZIP archives.
+
+Designed for the workflow where ``exaforge preprocess --format zip`` has
+packed a large directory of small files into a handful of ZIP archives.
+At runtime, archives can optionally be extracted to fast node-local
+storage (e.g. ``/tmp`` on Aurora) before reading, avoiding repeated
+decompression and Lustre metadata overhead.
+
+Supports the two-phase scan / read_by_ids workflow: file listings come
+from the ZIP central directory (one seek per archive), and only the
+requested entries are extracted.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+from exaforge.config import ZipTextReaderConfig
+
+from .base import BaseReader, InputItem
+
+logger = logging.getLogger(__name__)
+
+
+class ZipTextReader(BaseReader):
+    """Load text files packed inside ZIP archives.
+
+    If ``stage_dir`` is set in the config, each archive is extracted
+    there once on first access.  Subsequent reads hit the fast local
+    filesystem instead of the original archive / Lustre path.
+    """
+
+    def __init__(self, config: ZipTextReaderConfig) -> None:
+        self.config = config
+        self._index: Optional[dict[str, tuple[Path, str]]] = None
+        self._staged_dir: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+
+    def _discover_archives(self) -> list[Path]:
+        """Return deduplicated, sorted list of matching ZIP files."""
+        input_dir = self.config.input_dir
+        if not input_dir.is_dir():
+            raise FileNotFoundError(
+                f"Input directory does not exist: {input_dir}"
+            )
+
+        paths: list[Path] = []
+        for pattern in self.config.glob_patterns:
+            paths.extend(sorted(input_dir.glob(pattern)))
+
+        seen: set[Path] = set()
+        unique: list[Path] = []
+        for p in paths:
+            if p not in seen and p.is_file():
+                seen.add(p)
+                unique.append(p)
+        return unique
+
+    def _build_index(self) -> dict[str, tuple[Path, str]]:
+        """Build ``{item_id: (archive_path, entry_name)}`` from ZIP central dirs.
+
+        This only reads the ZIP table of contents — no file content is
+        decompressed — so it stays cheap even for thousands of archives.
+        """
+        if self._index is not None:
+            return self._index
+
+        archives = self._discover_archives()
+        index: dict[str, tuple[Path, str]] = {}
+
+        for archive_path in archives:
+            try:
+                with zipfile.ZipFile(archive_path, "r") as zf:
+                    for entry in zf.namelist():
+                        # Skip directories
+                        if entry.endswith("/"):
+                            continue
+                        item_id = Path(entry).stem
+                        index[item_id] = (archive_path, entry)
+            except (zipfile.BadZipFile, OSError) as exc:
+                logger.warning("Skipping bad archive %s: %s", archive_path, exc)
+
+        logger.info(
+            "Indexed %d items from %d ZIP archive(s)", len(index), len(archives)
+        )
+        self._index = index
+        return index
+
+    # ------------------------------------------------------------------
+    # Staging (optional: extract to fast local storage)
+    # ------------------------------------------------------------------
+
+    def _ensure_staged(self) -> Optional[Path]:
+        """Extract all archives to the staging directory (once).
+
+        Returns the staging root so reads can use the extracted files
+        instead of decompressing on every access.  Returns ``None`` if
+        staging is disabled.
+        """
+        if self.config.stage_dir is None:
+            return None
+
+        if self._staged_dir is not None:
+            return self._staged_dir
+
+        stage_root = Path(
+            tempfile.mkdtemp(
+                prefix="exaforge_staged_",
+                dir=str(self.config.stage_dir),
+            )
+        )
+        logger.info("Staging archives to %s …", stage_root)
+
+        for archive_path in self._discover_archives():
+            try:
+                with zipfile.ZipFile(archive_path, "r") as zf:
+                    zf.extractall(stage_root)
+            except (zipfile.BadZipFile, OSError) as exc:
+                logger.warning(
+                    "Skipping bad archive during staging %s: %s",
+                    archive_path,
+                    exc,
+                )
+
+        self._staged_dir = stage_root
+        logger.info("Staging complete: %s", stage_root)
+        return stage_root
+
+    # ------------------------------------------------------------------
+    # Two-phase API
+    # ------------------------------------------------------------------
+
+    def scan(self) -> list[str]:
+        """Return item IDs from ZIP central directories (no decompression)."""
+        return list(self._build_index().keys())
+
+    def read_by_ids(self, ids: set[str]) -> list[InputItem]:
+        """Load only items whose ID is in *ids*.
+
+        If staging is enabled, reads from the pre-extracted directory.
+        Otherwise, reads directly from the ZIP archives (grouping reads
+        by archive to minimise open/close overhead).
+        """
+        index = self._build_index()
+        stage_root = self._ensure_staged()
+
+        items: list[InputItem] = []
+        loaded = 0
+        target = len(ids)
+
+        if stage_root is not None:
+            # Fast path: read from pre-extracted files
+            for item_id in ids:
+                entry = index.get(item_id)
+                if entry is None:
+                    logger.warning("ID %r not in index — skipping", item_id)
+                    continue
+                _, entry_name = entry
+                staged_path = stage_root / entry_name
+                try:
+                    text = staged_path.read_text(
+                        encoding="utf-8", errors="replace"
+                    )
+                except OSError as exc:
+                    logger.warning("Skipping %s: %s", staged_path, exc)
+                    continue
+
+                items.append(
+                    InputItem(
+                        id=item_id,
+                        text=text,
+                        metadata={
+                            "source_file": str(staged_path),
+                            "archive_entry": entry_name,
+                        },
+                    )
+                )
+                loaded += 1
+                if loaded % 500 == 0:
+                    logger.info("Loaded %d / %d items …", loaded, target)
+        else:
+            # Direct path: read from ZIP archives, grouped by archive
+            by_archive: dict[Path, list[tuple[str, str]]] = {}
+            for item_id in ids:
+                entry = index.get(item_id)
+                if entry is None:
+                    logger.warning("ID %r not in index — skipping", item_id)
+                    continue
+                archive_path, entry_name = entry
+                by_archive.setdefault(archive_path, []).append(
+                    (item_id, entry_name)
+                )
+
+            for archive_path, entries in by_archive.items():
+                try:
+                    with zipfile.ZipFile(archive_path, "r") as zf:
+                        for item_id, entry_name in entries:
+                            try:
+                                raw = zf.read(entry_name)
+                                text = raw.decode("utf-8", errors="replace")
+                            except (KeyError, OSError) as exc:
+                                logger.warning(
+                                    "Skipping %s in %s: %s",
+                                    entry_name,
+                                    archive_path,
+                                    exc,
+                                )
+                                continue
+
+                            items.append(
+                                InputItem(
+                                    id=item_id,
+                                    text=text,
+                                    metadata={
+                                        "source_file": str(archive_path),
+                                        "archive_entry": entry_name,
+                                    },
+                                )
+                            )
+                            loaded += 1
+                            if loaded % 500 == 0:
+                                logger.info(
+                                    "Loaded %d / %d items …", loaded, target
+                                )
+                except (zipfile.BadZipFile, OSError) as exc:
+                    logger.warning(
+                        "Skipping bad archive %s: %s", archive_path, exc
+                    )
+
+        return items
+
+    # ------------------------------------------------------------------
+    # Legacy full-read API
+    # ------------------------------------------------------------------
+
+    def read(self) -> list[InputItem]:
+        all_ids = set(self._build_index().keys())
+        return self.read_by_ids(all_ids)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup_staging(self) -> None:
+        """Remove the staging directory if it was created."""
+        if self._staged_dir is not None and self._staged_dir.exists():
+            logger.info("Cleaning up staging dir: %s", self._staged_dir)
+            shutil.rmtree(self._staged_dir, ignore_errors=True)
+            self._staged_dir = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,36 @@ def large_sample_texts(tmp_dir: Path) -> list[Path]:
         p.write_text(f"Full text of large-corpus document {i}.\n")
         files.append(p)
     return files
+
+
+@pytest.fixture()
+def sample_mmd_dir(tmp_dir: Path) -> Path:
+    """Create a directory with 12 .mmd files for preprocessing tests."""
+    mmd_dir = tmp_dir / "papers"
+    mmd_dir.mkdir()
+    for i in range(12):
+        p = mmd_dir / f"paper_{i:03d}.mmd"
+        p.write_text(f"# Paper {i}\n\nThis is the parsed markdown for paper {i}.\n")
+    return mmd_dir
+
+
+@pytest.fixture()
+def preprocessed_jsonl_dir(tmp_dir: Path, sample_mmd_dir: Path) -> Path:
+    """Run jsonl preprocessing on sample_mmd_dir and return the output dir."""
+    import zipfile
+
+    from exaforge.preprocess import preprocess_to_jsonl
+
+    out = tmp_dir / "preprocessed_jsonl"
+    preprocess_to_jsonl(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+    return out
+
+
+@pytest.fixture()
+def preprocessed_zip_dir(tmp_dir: Path, sample_mmd_dir: Path) -> Path:
+    """Run zip preprocessing on sample_mmd_dir and return the output dir."""
+    from exaforge.preprocess import preprocess_to_zip
+
+    out = tmp_dir / "preprocessed_zip"
+    preprocess_to_zip(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+    return out

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,327 @@
+"""Tests for the ExaForge preprocessing pipeline and new readers."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from exaforge.cli import app
+from exaforge.config import JsonlReaderConfig, ZipTextReaderConfig
+from exaforge.preprocess import preprocess_to_jsonl, preprocess_to_zip
+from exaforge.readers import ZipTextReader, get_reader
+from exaforge.readers.jsonl import JsonlReader
+
+runner = CliRunner()
+
+
+# ------------------------------------------------------------------
+# preprocess_to_jsonl
+# ------------------------------------------------------------------
+
+
+class TestPreprocessToJsonl:
+    def test_creates_shards(self, sample_mmd_dir: Path, tmp_dir: Path) -> None:
+        out = tmp_dir / "jsonl_out"
+        total = preprocess_to_jsonl(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+        assert total == 12
+        shards = sorted(out.glob("batch_*.jsonl"))
+        # 12 files / 5 per shard = 3 shards (5 + 5 + 2)
+        assert len(shards) == 3
+
+    def test_shard_contents_valid_jsonl(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "jsonl_out"
+        preprocess_to_jsonl(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+        for shard in out.glob("batch_*.jsonl"):
+            for line in shard.read_text().strip().splitlines():
+                record = json.loads(line)
+                assert "id" in record
+                assert "text" in record
+                assert "source_file" in record
+                assert len(record["text"]) > 0
+
+    def test_custom_base_name(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "jsonl_out"
+        preprocess_to_jsonl(
+            sample_mmd_dir, out, ["*.mmd"], batch_size=100, base_name="papers"
+        )
+        shards = list(out.glob("papers_*.jsonl"))
+        assert len(shards) == 1
+        assert shards[0].name == "papers_0000.jsonl"
+
+    def test_empty_dir_returns_zero(self, tmp_dir: Path) -> None:
+        empty = tmp_dir / "empty"
+        empty.mkdir()
+        out = tmp_dir / "out"
+        total = preprocess_to_jsonl(empty, out, ["*.mmd"])
+        assert total == 0
+
+    def test_missing_dir_raises(self, tmp_dir: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            preprocess_to_jsonl(tmp_dir / "nope", tmp_dir / "out", ["*.mmd"])
+
+
+# ------------------------------------------------------------------
+# preprocess_to_zip
+# ------------------------------------------------------------------
+
+
+class TestPreprocessToZip:
+    def test_creates_archives(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "zip_out"
+        total = preprocess_to_zip(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+        assert total == 12
+        archives = sorted(out.glob("batch_*.zip"))
+        assert len(archives) == 3
+
+    def test_archive_contents(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "zip_out"
+        preprocess_to_zip(sample_mmd_dir, out, ["*.mmd"], batch_size=5)
+        all_entries: list[str] = []
+        for archive in out.glob("batch_*.zip"):
+            with zipfile.ZipFile(archive, "r") as zf:
+                all_entries.extend(zf.namelist())
+        assert len(all_entries) == 12
+        assert "paper_000.mmd" in all_entries
+
+    def test_empty_dir_returns_zero(self, tmp_dir: Path) -> None:
+        empty = tmp_dir / "empty"
+        empty.mkdir()
+        out = tmp_dir / "out"
+        total = preprocess_to_zip(empty, out, ["*.mmd"])
+        assert total == 0
+
+
+# ------------------------------------------------------------------
+# Enhanced JsonlReader (scan / read_by_ids)
+# ------------------------------------------------------------------
+
+
+class TestJsonlReaderTwoPhase:
+    def test_scan_returns_ids(self, preprocessed_jsonl_dir: Path) -> None:
+        cfg = JsonlReaderConfig(
+            input_dir=preprocessed_jsonl_dir,
+            glob_patterns=["*.jsonl"],
+        )
+        reader = JsonlReader(cfg)
+        ids = reader.scan()
+        assert len(ids) == 12
+        assert "paper_000" in ids
+
+    def test_read_by_ids_loads_subset(
+        self, preprocessed_jsonl_dir: Path
+    ) -> None:
+        cfg = JsonlReaderConfig(
+            input_dir=preprocessed_jsonl_dir,
+            glob_patterns=["*.jsonl"],
+        )
+        reader = JsonlReader(cfg)
+        items = reader.read_by_ids({"paper_001", "paper_005", "paper_010"})
+        assert len(items) == 3
+        ids = {it.id for it in items}
+        assert ids == {"paper_001", "paper_005", "paper_010"}
+
+    def test_scan_then_read_all_matches_full_read(
+        self, preprocessed_jsonl_dir: Path
+    ) -> None:
+        cfg = JsonlReaderConfig(
+            input_dir=preprocessed_jsonl_dir,
+            glob_patterns=["*.jsonl"],
+        )
+        reader = JsonlReader(cfg)
+        all_ids = set(reader.scan())
+        selective = reader.read_by_ids(all_ids)
+        full = JsonlReader(cfg).read()
+        assert {it.id for it in selective} == {it.id for it in full}
+
+    def test_read_by_ids_empty_set(
+        self, preprocessed_jsonl_dir: Path
+    ) -> None:
+        cfg = JsonlReaderConfig(
+            input_dir=preprocessed_jsonl_dir,
+            glob_patterns=["*.jsonl"],
+        )
+        items = JsonlReader(cfg).read_by_ids(set())
+        assert items == []
+
+    def test_index_is_cached(self, preprocessed_jsonl_dir: Path) -> None:
+        cfg = JsonlReaderConfig(
+            input_dir=preprocessed_jsonl_dir,
+            glob_patterns=["*.jsonl"],
+        )
+        reader = JsonlReader(cfg)
+        reader.scan()
+        reader.scan()
+        assert reader._index is not None
+
+
+# ------------------------------------------------------------------
+# ZipTextReader
+# ------------------------------------------------------------------
+
+
+class TestZipTextReader:
+    def test_scan_returns_ids(self, preprocessed_zip_dir: Path) -> None:
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+        )
+        reader = ZipTextReader(cfg)
+        ids = reader.scan()
+        assert len(ids) == 12
+        assert "paper_000" in ids
+
+    def test_read_by_ids_direct(self, preprocessed_zip_dir: Path) -> None:
+        """Read directly from zip archives (no staging)."""
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+        )
+        reader = ZipTextReader(cfg)
+        items = reader.read_by_ids({"paper_002", "paper_007"})
+        assert len(items) == 2
+        ids = {it.id for it in items}
+        assert ids == {"paper_002", "paper_007"}
+        for it in items:
+            assert "Paper" in it.text
+            assert "archive_entry" in it.metadata
+
+    def test_read_by_ids_staged(
+        self, preprocessed_zip_dir: Path, tmp_dir: Path
+    ) -> None:
+        """Read via staging to a temp directory."""
+        stage = tmp_dir / "staging"
+        stage.mkdir()
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+            stage_dir=stage,
+        )
+        reader = ZipTextReader(cfg)
+        items = reader.read_by_ids({"paper_003", "paper_011"})
+        assert len(items) == 2
+        # Verify staged files exist
+        assert reader._staged_dir is not None
+        assert reader._staged_dir.exists()
+        reader.cleanup_staging()
+        assert reader._staged_dir is None
+
+    def test_full_read(self, preprocessed_zip_dir: Path) -> None:
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+        )
+        items = ZipTextReader(cfg).read()
+        assert len(items) == 12
+
+    def test_scan_then_read_matches_full_read(
+        self, preprocessed_zip_dir: Path
+    ) -> None:
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+        )
+        reader = ZipTextReader(cfg)
+        all_ids = set(reader.scan())
+        selective = reader.read_by_ids(all_ids)
+        full = ZipTextReader(cfg).read()
+        assert {it.id for it in selective} == {it.id for it in full}
+
+    def test_read_by_ids_empty_set(
+        self, preprocessed_zip_dir: Path
+    ) -> None:
+        cfg = ZipTextReaderConfig(
+            input_dir=preprocessed_zip_dir,
+            glob_patterns=["*.zip"],
+        )
+        items = ZipTextReader(cfg).read_by_ids(set())
+        assert items == []
+
+
+# ------------------------------------------------------------------
+# Reader registry with zip_text
+# ------------------------------------------------------------------
+
+
+class TestReaderRegistryZipText:
+    def test_get_reader_zip_text(self, tmp_dir: Path) -> None:
+        reader = get_reader(
+            {"name": "zip_text", "input_dir": str(tmp_dir)}
+        )
+        assert isinstance(reader, ZipTextReader)
+
+    def test_get_reader_from_config_object(self, tmp_dir: Path) -> None:
+        cfg = ZipTextReaderConfig(input_dir=tmp_dir)
+        reader = get_reader(cfg)
+        assert isinstance(reader, ZipTextReader)
+
+
+# ------------------------------------------------------------------
+# CLI preprocess command
+# ------------------------------------------------------------------
+
+
+class TestPreprocessCommand:
+    def test_preprocess_jsonl(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "cli_jsonl"
+        result = runner.invoke(
+            app,
+            [
+                "preprocess",
+                "-i", str(sample_mmd_dir),
+                "-o", str(out),
+                "-f", "jsonl",
+                "-g", "*.mmd",
+                "-K", "5",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Preprocessed 12" in result.output
+        assert len(list(out.glob("batch_*.jsonl"))) == 3
+
+    def test_preprocess_zip(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "cli_zip"
+        result = runner.invoke(
+            app,
+            [
+                "preprocess",
+                "-i", str(sample_mmd_dir),
+                "-o", str(out),
+                "-f", "zip",
+                "-g", "*.mmd",
+                "-K", "5",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Preprocessed 12" in result.output
+        assert len(list(out.glob("batch_*.zip"))) == 3
+
+    def test_preprocess_unknown_format(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "preprocess",
+                "-i", str(sample_mmd_dir),
+                "-o", str(tmp_dir / "out"),
+                "-f", "parquet",
+                "-g", "*.mmd",
+            ],
+        )
+        assert result.exit_code != 0

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -285,7 +285,7 @@ class TestPreprocessCommand:
                 "-o", str(out),
                 "-f", "jsonl",
                 "-g", "*.mmd",
-                "-K", "5",
+                "-b", "5",
             ],
         )
         assert result.exit_code == 0
@@ -304,12 +304,31 @@ class TestPreprocessCommand:
                 "-o", str(out),
                 "-f", "zip",
                 "-g", "*.mmd",
-                "-K", "5",
+                "-b", "5",
             ],
         )
         assert result.exit_code == 0
         assert "Preprocessed 12" in result.output
         assert len(list(out.glob("batch_*.zip"))) == 3
+
+    def test_preprocess_jsonl_multithreaded(
+        self, sample_mmd_dir: Path, tmp_dir: Path
+    ) -> None:
+        out = tmp_dir / "cli_jsonl_mt"
+        result = runner.invoke(
+            app,
+            [
+                "preprocess",
+                "-i", str(sample_mmd_dir),
+                "-o", str(out),
+                "-f", "jsonl",
+                "-g", "*.mmd",
+                "-b", "5",
+                "-w", "4",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(list(out.glob("batch_*.jsonl"))) == 3
 
     def test_preprocess_unknown_format(
         self, sample_mmd_dir: Path, tmp_dir: Path


### PR DESCRIPTION
I added a preprocessing utility to the CLI so that the user can now batch their inference data. This reduces I/O latency tremendously in cases where the user has to submit thousands of files in a directory for some inference, and these files need to be read individually. 

I also implemented/modified readers for handling this type of batched submission.