### PR TITLE
Location of Endpoint File will now be derived from the timestamp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,21 @@ aegis:
     config_path: /path/to/aegis_config.yaml  # Aegis YAML (required if auto_launch)
     auto_launch: true                         # Submit PBS job automatically
     wait_for_endpoints: true                  # Block until endpoints healthy
-    endpoints_file: aegis_endpoints.txt       # Path to endpoints file
+    local_runs_dir: local_runs               # Base dir for timestamped run directories
+    # endpoints_file: ...                    # See below
 ```
+
+**`endpoints_file` rules:**
+
+| `auto_launch` | `endpoints_file` | Behaviour |
+|---|---|---|
+| `true` | omitted *(recommended)* | Endpoints written to `local_runs/<timestamp>/aegis_endpoints.txt` automatically |
+| `true` | set | Used as-is; must match the `endpoints_file` in the Aegis YAML or ExaForge will error |
+| `false` | set | Read from this path (Aegis already ran separately) |
+| `false` | omitted | Error — ExaForge has no idea where to find the file |
+
+When using `auto_launch: true` you should also remove `endpoints_file` from the
+Aegis YAML — ExaForge overrides it to the run-specific path anyway.
 
 ### Task section
 

--- a/configs/aegis_configs/single_file.yaml
+++ b/configs/aegis_configs/single_file.yaml
@@ -5,7 +5,6 @@ walltime: "01:00:00"
 account: ModCon
 queue: debug-scaling
 filesystems: flare:home
-endpoints_file: /home/ogokdemir/ExaForge/local_runs/aegis_endpoints.txt
 conda_env: /home/ogokdemir/Aegis/assets/condapacks/vllm_oss_conda_pack_01082026.tar.gz
 aegis_env: /home/ogokdemir/.conda/envs/exaforge-env/
 

--- a/configs/task_configs/data_card_extract_test.yaml
+++ b/configs/task_configs/data_card_extract_test.yaml
@@ -11,7 +11,7 @@ aegis:
     config_path: /home/ogokdemir/ExaForge/configs/aegis_configs/single_file.yaml
     auto_launch: true
     wait_for_endpoints: true
-    endpoints_file: /home/ogokdemir/ExaForge/local_runs/aegis_endpoints.txt
+    # endpoints_file: omitted — ExaForge will write to local_runs/<timestamp>/aegis_endpoints.txt automatically
 
 task:
     name: card_extraction

--- a/src/exaforge/aegis_bridge.py
+++ b/src/exaforge/aegis_bridge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -65,7 +66,6 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     from aegis.config import load_config as load_aegis_config
     from aegis.scheduler import (
         generate_pbs_script,
-        make_run_dir,
         submit_job,
         wait_for_endpoints,
     )
@@ -81,7 +81,8 @@ def launch_aegis(config: AegisConfig) -> list[str]:
 
     # All run artifacts (PBS script, logs, endpoints file) go into a
     # timestamped sub-directory of local_runs_dir.
-    run_dir = make_run_dir(config.local_runs_dir)
+    run_dir = config.local_runs_dir / datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir.mkdir(parents=True, exist_ok=True)
     run_endpoints_file = run_dir / "aegis_endpoints.txt"
     logger.info("Run directory: %s", run_dir)
 

--- a/src/exaforge/aegis_bridge.py
+++ b/src/exaforge/aegis_bridge.py
@@ -79,12 +79,25 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     logger.info("Loading Aegis config from %s", aegis_config_path)
     aegis_cfg = load_aegis_config(aegis_config_path)
 
-    # Generate a timestamped run directory. Aegis writes all artifacts there.
-    # launcher.py will also create local_runs/aegis_endpoints.txt as a symlink,
-    # so ExaForge's config.endpoints_file (pointing to local_runs/) needs no change.
-    run_dir = make_run_dir(config.endpoints_file.parent.parent)  # ExaForge project root
-    aegis_cfg.endpoints_file = str(run_dir / "aegis_endpoints.txt")
+    # All run artifacts (PBS script, logs, endpoints file) go into a
+    # timestamped sub-directory of local_runs_dir.
+    run_dir = make_run_dir(config.local_runs_dir)
+    run_endpoints_file = run_dir / "aegis_endpoints.txt"
     logger.info("Run directory: %s", run_dir)
+
+    # Validate consistency if user explicitly set endpoints_file.
+    if config.endpoints_file is not None:
+        aegis_raw = Path(aegis_cfg.endpoints_file) if getattr(aegis_cfg, "endpoints_file", None) else None
+        if aegis_raw is not None and aegis_raw.resolve() != config.endpoints_file.resolve():
+            raise ValueError(
+                f"endpoints_file mismatch between ExaForge config "
+                f"({config.endpoints_file}) and Aegis config ({aegis_raw}). "
+                "Set both to the same path, or omit endpoints_file from the "
+                "ExaForge config to use the run directory automatically."
+            )
+
+    # Always write to the run-specific path regardless of what Aegis config says.
+    aegis_cfg.endpoints_file = str(run_endpoints_file)
 
     logger.info("Generating PBS script")
     script = generate_pbs_script(aegis_cfg, run_dir=run_dir)
@@ -94,7 +107,6 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     logger.info("Submitting PBS job")
     job_id = submit_job(script, hf_token=hf_token, run_dir=run_dir)
 
-    endpoints_file = str(config.endpoints_file)
     logger.info("Waiting for endpoints (job %s)", job_id)
     print(
         "Waiting for vLLM instances to come online...",
@@ -103,7 +115,7 @@ def launch_aegis(config: AegisConfig) -> list[str]:
     )
 
     endpoints = wait_for_endpoints(
-        endpoints_file=endpoints_file,
+        endpoints_file=str(run_endpoints_file),
         job_id=job_id,
     )
     logger.info("Aegis ready: %d endpoint(s)", len(endpoints))
@@ -129,7 +141,10 @@ def get_endpoint_pool(config: AegisConfig) -> EndpointPool:
     """
     if config.auto_launch:
         endpoints_lines = launch_aegis(config)
-        # The endpoints file has been written by Aegis; load from it
-        return EndpointPool.from_file(config.endpoints_file)
+        return EndpointPool.from_lines(endpoints_lines)
 
+    if config.endpoints_file is None:
+        raise ValueError(
+            "aegis.endpoints_file must be set when auto_launch is false"
+        )
     return EndpointPool.from_file(config.endpoints_file)

--- a/src/exaforge/cli.py
+++ b/src/exaforge/cli.py
@@ -124,6 +124,13 @@ def status(
 
     from exaforge.endpoints import EndpointPool
 
+    if cfg.aegis.endpoints_file is None:
+        console.print(
+            "[red]aegis.endpoints_file is not set in config. "
+            "Run with auto_launch or specify endpoints_file.[/red]"
+        )
+        raise typer.Exit(1)
+
     try:
         pool = EndpointPool.from_file(cfg.aegis.endpoints_file)
     except FileNotFoundError:

--- a/src/exaforge/config.py
+++ b/src/exaforge/config.py
@@ -14,6 +14,9 @@ from typing import Literal, Optional, TypeVar, Union
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
+# Absolute path to the repository root (src/exaforge/config.py → ../../..)
+_REPO_ROOT: Path = Path(__file__).parents[2]
+
 T = TypeVar("T")
 PathLike = Union[str, Path]
 
@@ -60,7 +63,7 @@ class AegisConfig(BaseConfig):
     config_path: Optional[Path] = None
     auto_launch: bool = False
     wait_for_endpoints: bool = True
-    local_runs_dir: Path = Path("local_runs")
+    local_runs_dir: Path = _REPO_ROOT / "local_runs"
     endpoints_file: Optional[Path] = Field(
         default=None,
         description=(

--- a/src/exaforge/config.py
+++ b/src/exaforge/config.py
@@ -60,7 +60,18 @@ class AegisConfig(BaseConfig):
     config_path: Optional[Path] = None
     auto_launch: bool = False
     wait_for_endpoints: bool = True
-    endpoints_file: Path = Path("aegis_endpoints.txt")
+    local_runs_dir: Path = Path("local_runs")
+    endpoints_file: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Path to the Aegis endpoints file. "
+            "When auto_launch is true this can be omitted — ExaForge will "
+            "write endpoints to a timestamped sub-directory of local_runs_dir. "
+            "When auto_launch is false this must point to an existing file. "
+            "If set together with auto_launch and the Aegis config also "
+            "specifies endpoints_file, the two paths must match."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/exaforge/endpoints.py
+++ b/src/exaforge/endpoints.py
@@ -102,6 +102,25 @@ class EndpointPool:
             health_interval=health_interval,
         )
 
+    @classmethod
+    def from_lines(
+        cls,
+        lines: list[str],
+        strategy: str = "round_robin",
+        health_interval: float = 30.0,
+    ) -> "EndpointPool":
+        """Create a pool from a list of ``host:port`` strings."""
+        endpoints = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            url = line if line.startswith("http") else f"http://{line}"
+            endpoints.append(Endpoint(url=url))
+        if not endpoints:
+            raise ValueError("No endpoints found in provided lines")
+        return cls(endpoints, strategy=strategy, health_interval=health_interval)
+
     # ------------------------------------------------------------------
     # Health checking
     # ------------------------------------------------------------------

--- a/tests/test_aegis_bridge.py
+++ b/tests/test_aegis_bridge.py
@@ -36,6 +36,11 @@ class TestGetEndpointPool:
         with pytest.raises(FileNotFoundError):
             get_endpoint_pool(cfg)
 
+    def test_no_endpoints_file_without_auto_launch_raises(self) -> None:
+        cfg = AegisConfig(auto_launch=False, endpoints_file=None)
+        with pytest.raises(ValueError, match="endpoints_file"):
+            get_endpoint_pool(cfg)
+
     def test_auto_launch_without_aegis_raises(
         self, tmp_dir: Path
     ) -> None:
@@ -68,7 +73,7 @@ class TestGetEndpointPool:
         cfg = AegisConfig(
             auto_launch=True,
             config_path=aegis_yaml,
-            endpoints_file=endpoints_file,
+            local_runs_dir=tmp_dir,
         )
 
         mock_aegis_cfg = MagicMock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ import yaml
 
 from exaforge.config import (
     AegisConfig,
+    _REPO_ROOT,
     CardExtractionTaskConfig,
     CheckpointConfig,
     ClientConfig,
@@ -49,7 +50,7 @@ class TestSubConfigs:
         cfg = AegisConfig()
         assert cfg.auto_launch is False
         assert cfg.endpoints_file is None
-        assert cfg.local_runs_dir == Path("local_runs")
+        assert cfg.local_runs_dir == _REPO_ROOT / "local_runs"
 
     def test_client_defaults(self) -> None:
         cfg = ClientConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,8 @@ class TestSubConfigs:
     def test_aegis_defaults(self) -> None:
         cfg = AegisConfig()
         assert cfg.auto_launch is False
-        assert cfg.endpoints_file == Path("aegis_endpoints.txt")
+        assert cfg.endpoints_file is None
+        assert cfg.local_runs_dir == Path("local_runs")
 
     def test_client_defaults(self) -> None:
         cfg = ClientConfig()


### PR DESCRIPTION
fix: auto-derive endpoints path from timestamped run dir
Previously ExaForge and Aegis configs both required a hardcoded
endpoints_file path that had to be kept in sync manually. The bridge
wrote the file to a run-specific directory but polled the flat path,
causing wait_for_endpoints to hang indefinitely.

- AegisConfig.endpoints_file is now Optional (default None); when
  omitted with auto_launch the bridge resolves the path from the
  timestamped run dir automatically
- Added AegisConfig.local_runs_dir (default "local_runs") as the base
  for run directories
- launch_aegis validates consistency when endpoints_file is explicitly
  set and errors loudly on mismatch
- get_endpoint_pool raises ValueError when auto_launch is false and
  endpoints_file is None
- Added EndpointPool.from_lines() to build a pool from already-loaded
  endpoint strings
- status command handles None endpoints_file with a clear message
- Removed endpoints_file from both config files; ExaForge now manages
  it entirely